### PR TITLE
feat: implement MCTSNode data structure

### DIFF
--- a/src/Urrutia_Dario_Alfonso/solution.py
+++ b/src/Urrutia_Dario_Alfonso/solution.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import math
+
+try:
+    from board import HexBoard
+except ImportError:
+    from src.Urrutia_Dario_Alfonso.board import HexBoard
+
+
+class MCTSNode:
+    """
+    A node in the MonteCarlo Tree Search algorithm
+    """
+
+    def __init__(
+        self,
+        board: HexBoard,
+        move: tuple[int, int] | None = None,
+        parent: MCTSNode | None = None,
+    ):
+        """
+        Initializes a new MCTSNode.
+
+        Args:
+            board: The current state of the game board.
+            move: The move that led to this node (row, col), or None for the root node.
+            parent: The parent node in the search tree, or None for the root node.
+        """
+        self.board = board
+        self.move = move
+        self.parent = parent
+        self.children: list[MCTSNode] = []
+        self.visits = 0
+        self.wins = 0
+
+    def is_fully_expanded(self, untried_moves: list[tuple[int, int]]) -> bool:
+        """
+        Checks if the node is fully expanded.
+
+        Args:
+            untried_moves: The list of moves that have not been tried yet.
+
+        Returns:
+            True if the node is fully expanded, False otherwise.
+        """
+        return not untried_moves
+
+    def best_child(self, c_param: float = math.sqrt(2)) -> MCTSNode:
+        """
+        Selects the best child node based on:
+          the UCT (Upper Confidence Bound for Trees) formula.
+
+        Args:
+            c_param: The exploration parameter that balances
+            exploration and exploitation.
+
+        Returns:
+            The child node with the highest UCT value.
+        """
+
+        return max(
+            self.children,
+            key=lambda child: (
+                child.wins / child.visits
+                + c_param * math.sqrt(math.log(self.visits) / child.visits)
+            ),
+        )

--- a/tests/test_mcts_node.py
+++ b/tests/test_mcts_node.py
@@ -1,0 +1,79 @@
+from src.Urrutia_Dario_Alfonso.board import HexBoard
+from src.Urrutia_Dario_Alfonso.solution import MCTSNode
+
+# Test initialization
+
+
+def test_mcts_node_initialization():
+    """
+    Tests that an MCTSNode is initialized correctly.
+    """
+
+    # Arrange
+
+    board = HexBoard(size=5)
+    root = MCTSNode(board=board)
+
+    # Act + Assert
+    assert root.board == board
+    assert root.move is None
+    assert root.parent is None
+    assert root.children == []
+    assert root.visits == 0
+    assert root.wins == 0
+
+
+# Test is_fully_expanded
+
+
+def test_is_fully_expanded_when_no_moves_left():
+    """
+    Tests that is_fully_expanded returns True when there are no untried moves left.
+    """
+
+    # Arrange
+    board = HexBoard(size=5)
+    node = MCTSNode(board=board)
+    untried_moves = []
+
+    # Act + Assert
+    assert node.is_fully_expanded(untried_moves)
+
+
+def test_is_fully_expanded_when_moves_left():
+    """
+    Tests that is_fully_expanded returns False when there are untried moves left.
+    """
+
+    # Arrange
+    board = HexBoard(size=5)
+    node = MCTSNode(board=board)
+    untried_moves = [(0, 0), (0, 1)]
+
+    # Act + Assert
+    assert not node.is_fully_expanded(untried_moves)
+
+
+# Test best_child
+def test_best_child_returns_child_with_highest_uct():
+    """
+    Tests that best_child returns the child with the highest UCT value.
+    """
+
+    # Arrange
+    board = HexBoard(size=5)
+    parent_node = MCTSNode(board=board)
+    child1 = MCTSNode(board=board, parent=parent_node)
+    child1.visits = 10
+    child1.wins = 5
+    child2 = MCTSNode(board=board, parent=parent_node)
+    child2.visits = 20
+    child2.wins = 15
+    parent_node.children = [child1, child2]
+    parent_node.visits = 30
+
+    # Act
+    best_child = parent_node.best_child(c_param=1.0)
+
+    # Assert
+    assert best_child == child2


### PR DESCRIPTION
## What this PR does
Implements the `MCTSNode` class in `solution.py` — the tree node
that MCTS uses to track game state at each decision point.

## Design Decisions
- Single Responsibility: node only manages state and UCB1 selection
- `children` initialized inside body, never as default parameter (mutable default trap)
- `try/except` import handles both tournament and pytest environments

## Changes
- Added `MCTSNode` class in `src/Urrutia_Dario_Alfonso/solution.py`
- Added 4 unit tests in `tests/test_mcts_node.py`

## Related Issue
Closes #7