### PR TITLE
fix: correct HexBoard neighbor directions for even-r layout

### DIFF
--- a/src/Urrutia_Dario_Alfonso/board.py
+++ b/src/Urrutia_Dario_Alfonso/board.py
@@ -112,9 +112,9 @@ class HexBoard(AbstractBoard):
         neighbors = []
 
         if row % 2 == 0:
-            directions = [(-1, -1), (-1, 0), (-1, 1), (0, 1), (1, 0), (0, -1)]
+            directions = [(-1, 0), (-1, 1), (0, -1), (0, 1), (1, 0), (1, 1)]
         else:
-            directions = [(0, -1), (-1, 0), (0, 1), (1, 1), (1, 0), (1, -1)]
+            directions = [(-1, -1), (-1, 0), (0, -1), (0, 1), (1, -1), (1, 0)]
 
         for dr, dc in directions:
             new_row, new_col = row + dr, col + dc


### PR DESCRIPTION
## What this PR does
Fixes incorrect direction vectors in `_get_neighbors` in `board.py`.

## 🐛 The Bug
The even-r hex layout directions were swapped and incorrect,
causing wrong neighbors to be computed for both even and odd rows.

## ✅ The Fix
Even rows: [(-1,0), (-1,1), (0,-1), (0,1), (1,0), (1,1)]
Odd rows:  [(-1,-1), (-1,0), (0,-1), (0,1), (1,-1), (1,0)]

## ✔️ Verified
Manually verified with teacher's examples:
- (2,2) → (1,2), (1,3), (2,1), (2,3), (3,2), (3,3) ✅
- (3,3) → (2,2), (2,3), (3,2), (3,4), (4,2), (4,3) ✅

## Related Issue
Closes #11