### PR TITLE
feat: improve SmartPlayer with opening book, bridge save and UCB1 tuning

### DIFF
--- a/src/Urrutia_Dario_Alfonso/estrategia.pdf
+++ b/src/Urrutia_Dario_Alfonso/estrategia.pdf
@@ -22,7 +22,7 @@ endobj
 endobj
 5 0 obj
 <<
-/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -32,7 +32,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -42,58 +42,77 @@ endobj
 endobj
 7 0 obj
 <<
-/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 8 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260323011754+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260323011754+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
 >>
 endobj
 9 0 obj
 <<
-/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+/Author (\(anonymous\)) /CreationDate (D:20260325100719+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260325100719+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1621
+/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
 >>
-stream
-Gatm:gMYe)&:O:S9]"@"]3.^PYlb,_j#C_0`,OZEcj.82'"su)OYTLFm!O6-E$_XQ3bfQIlcXmHRGg/I%[kZPT-XCf.\aCfHM'Iq,c1/C-1gAkefX.(I;jClZn#4uZogpb(h;$*QCKK>gAaC/AXIS/!sD6mfSEQODG'/Pj/+7q9i%Y0%$U"?-KdQP&`cCf.]'",RZ/_tUXLRNfeP@lZ5BLsci6&%oe!:Qd]\;Z..9rZ*gaC*mn0+hZ0rB[K>rM+=O?-8F%nn+mt=W*:A'T(hGTrB/%Tir5o.:GpP75#Lh@AS@cF;\l)[<iG.^LM$Qt_+b`R(;cEed#rM..sLKK_Y!fpiBaV<:,<gS@!Y0""=6D(=cP0Sa0QI\f'\rsoF?[`qEENtmj@C+%$E0?T8)0;Ec\o$N*,D)_b`_[5u>.Q\<EIU8?8L&LcqH=R_N_:HZVN4AV:i3n_(/M>W6'];_]2C#C_MKWpPN4o!N];\<H.T!sd#nP,8m_.0,<sgmnnaRl]Wi([&Ks`7kHfFHcp>BAK[S7YNDWpE5d7rqdVV#/PSi*s9X(%O<7R:-o"N]+$-*uFTY%Y$$<u%aL0/.=$g!X2EhB4n-H'D-dNE=&WPIg:,fG]8,BTVO3ut)3No0k3f68-co#[f9oi6H3:ARHFD<+2bm4<"O"BDa,K""bi-ChFGa@3=0`+s>K+&51t0%/Jt'5VB<n/RRWjAj`D@Am)J3L4lrpL3UbJQI`'iMCmaQsPNl#?@u[F=gkQXfB`\!Sh_1!G8^W7Mt*]FO$FT9,FkAf)b:&^pIeNM/L28KF[lYL!V6IU]Fm]_c&M!nb/34b1G4_L<(b6klQ!G)T,9OUMoj[jbMlTcKG4_)l-DYh\`<9LgA_:q5N3NePOr($F5jm$U>$Ep!c(eD's4%?Hgu8on\I>D-ac(D$JTS6mLp7_VB@hn"fh7,dXBn[Kq->$m+01Lc^N\4]-l%BMbhI@XD,Wh(TA*]2tJV"!Yu0h<$F+'0%^CB&mqVp=-et7;KFR<FF.u&?JO#`cQ=#.g_cUooE]O)uPB?Y9_V&=Qe`iHg9""Jp$^F8Q)#uZHu8g8jVfpRWfWMmh^+^RD.6<iO5%0hW+>*ln(shq-69qFCrdWJn,3[D_4qM+!/fG!G2o`0`l\'gG0"G0,Ep#E-KF>%n5j8hGuZrR8V7O/RTWR'RYct'h#;CnLt4WXHGlDs$/[gU"eN148LdpG1sg](?Q0TEh&_$GE&q0q<'J"o=c*J`sfr)]E*+]?Q"+W06BZ:aksXj:UJ4k(DqLQ$g_ghGrD\U1jNE6('[?;OaO3eeo/`tmisT-S<#iR]m);9Mpf]leGNpVm<Ci(d!UFd51uJXbn'in#h.JQ$7jp=lhnI4`rCRnP4:KWG7<q>5L[fqFr.olfOq_=KIIW\k@N/1gu!"]-&mc5Li<3t/VmP`AYsN;KINFMO!2unXaQp=l%crJU=Qgt9>7D&kcHM!U7\5GMgj72>.iX?`7L%(9[@hI0('eWXr+N`oIoXT*eV:u,2VVPCSE2P1E]CNb4$_I;7+NYk4JPZ<P4+_M>+fFFa3o<3WR`LYf>:b$82[6d2IJh5R\RGL%%_+Q`V[g<eZT'<Us>pYBg6O*W-B@h:8\~>endstream
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1702
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1592
 >>
 stream
-Gatm:9lo&I&A@7.m%lLYa.`;X4.aQf8aZ553c1V8oUlR[_@esRT`C`(qq(Qo5VeMCi@-"4/]%L2q;0l8Ro,&=(4OjedCU-!gh)f4[(<0:9M/K:TUXK4YHP6?kN*F1/)H4Bm*;I9We+8'AP53!m`>0`1jnYU(.([QNE)^<SX8t>:=;K_\"Y,#Og0o4c:M\&D'up7@*r38Yn`8'dNs"q]HFQTW`;ih<pO3tFD%t,T[g7<3_e$RX_@AL!q!*MaEf54mf_TXY@JjrC*`b'oC"P;abu.Eekg5;]p=+<8ScusE_<ce7.s5rOuFUQ:>pSZQ%g]6@n@X9g.T:+l)9fRFMb&&X#1iI%0@&GUP<SFKnHB-$Ma&_rOSp_a31l("L[BBQU<B;N3udNq'A%R84(e=l@]X4(p^I3CDeAd90B03*C$\CGMtNFn:is%&cgs*;,5:Z2nZ^c,;F6fs3Vto^o=co,8\Ih2"^>L5,XjkQVfQ6+J+FF[<$>W%mcqI(4Q^)W2+s[-gAGmI`-C<GWckI\kM8g(7-abFrKm?"'F/j&&oJ\^jGX4ZsI;8Fs?Gr2nd0oCQ0.G"Hjg(U`GI$'%X(B#ZuB$(^J0mM;'Ya1fAu)<coD/+XWfV5=8h+fa1\C;R$:LWLa`KcY<cU<**;GnjT99MiBO%;huPUVn@!3>]GXErPfhR&*\!HMm,9,I]QI,95@N9ZmP%f1;Bn=amqA:lm'Wq+p5nN-FsJe?No)?KK`$\lgJtjl*%''ka$?UQUY-&P.c87,2'_F&mGo[>l`]%iL=lq:MLj"G3WMc_#QZO7'1\:9&7(gbZje'mk@8:Z6O%a:-?GspqJf-2V,/B.Sq'uJc><fJ9G4_E//[Z'=J5BNFpY-DFQZ^3R7mF?-N%u&3Yb1#T`a=o);pL6AL\:@CO-I3E#?N.+NDP$5rb8S)`668m5I-O4J-^,=N66C`!cI<BV2_O>%1#.sBQu^3&mF(pkhgIlVe$g&nr9<%tjl_@\GZ9?kk$+h,1DQS"ieogi)ONi-MI>@p)gZXlHF:Rf`SPg@C)0pbFnQ#it=Wa8ZlLZauQH_limk]WP5\aI6=-\E0[*`tER<%P>`5U0HIOG&N<B0&/Lcb7\R`h(H234:6m>;5P;#AM^O_Jg#NCYJJAaISJmJk:R:\ef1[+O)CZ6AZRt3#@?M>k[UZ1L&mZ'/-\,R>2"DX<Xmo6=mUrWRelo[:32W4*^+c:2(L:6.@'N$P=O5JUF*La:SQ9[>gHL%:.t,6@Wr3i*Zi\I<K9-b)=g;#A>h`n=M,NBqBQXJs`d,haBV&)Fm`FfYMi@G\Ki:b#XCVi.9#F6K:TjN@'Q;'d.=++58DEjOIZEbFQYWiGcThLUtMk0rNFs.fC7(;C-#7^r15j3d1=!6uFo:Ct@D%h"ahq+'E%*(^(43RfF].[-EM9^>2ZTijbs:ph1VCAAUS=$,VN/Z?pF3l?`\S9i1;4%DM6'>!.Lu5r0>^GkPC7%:-Q2R`d#dPHg6'_-O1qg31i]Q7655XbEoF^N[`dbBppZOf2.NW(/%9Ku/A"U<G&37klHk]FEa2qS4!Ej3Ds%XXTFm.Z._(.iTd:/R4jq7'^5`0Pt3^'fn$-9]j5c@=!`6biV2XEFr6Ofi?=^5$sj&g%(!_2"7"?SfoTdcY&HQVOdI.GC=J9<??cf!kL%600a#^Su1TQd!cG,*i4:N)SPthPTT&.~>endstream
+Gatm:hbW;k&:WfGR!W&?gTXHH#CFmu!fg3_l6.VmW=Sk],\AcOlsMo%d(d:NhBX$gjP!Odi(f;Fk4<ulIC=Y4rJ:5-0*+gLE:d:`87?WK@[]u!ofJ\I%NZ*JZZC*po4:O`Be9o1Z()3Ss*HlMkbHlP:a4<KVJIR?9d-'HhDF>qkq\Z>oPmmHkhHDu6#IB'+Z90uDm6GU:?o(/k*`KNV02S+r6I`4h8AM@r7m2WG^n)dF,5b=%cSb:]`Ep!)?G[#BQWWH*=0M0FNVIW^9tsb=JtBb/tIERH*A"]jeN(MC>i;Hr,OZc1``&*cdTjl3gD=q<&R=GRE-0D!'"aU-F*pH3!'d#Tiip!WAP4Z3h$HNC/'e/L/(rT3@WoZU<E"S)1ji;9nmsMbIZhl=F2*)T51s?jea=*Uk.5b^`+k2>eG<oJ=r^#]InVd\Vf_$#9qX;/ao@<?;ZN6$=-I3qP8g+\jV<,EXM=b`0aJ*O:SbQU6^>JQ[%-DNVlV?=_EZ"jM2D#@YZ4BrglhQTF(0p+bEHV<ZAH3NX3'P?Fh^)9n6FecihN\6'VmaOH5[8%NPdp6?cosjL2.s$k[1sF6/ZEEaP]*-H'D-cpZHd<.Xd`P:1@f:T8D8fOTf@.K06i]&"84=HC1fXfg61i2!QQhF;r><6c,B&ttPD64PS_qV\.QC,lJkMYKH,GDFWm;&AJ63tlF=qs>8RQf(kHCG\j;k+&lh[!-6K^JDKUo:!/V8Rd"VD*FngD4r!GdV`&VEu'R9Si:C?NPl#1\cg<(;C^p?YO,&WEHK,U2Z,s%iEW>!^/U,]+;N6JXQ&qQFWA%WAVK]?2/sbiUM2J.gmd$e&6:VHHXQ0W@7I0Ds2,;o"?tFl<+^)N2BkB5)sV/dm1=kc3G8EriO,*M7!dUES!=ej2-M"Vnb8#Yk@C'uePFQu3jCC5XnGu`55!%ak_LHM]Q+0O@2`WdhQVc\W)45YRTOCO$:Hh@#Ktr(:!F!Db`o!Ldo%aTYc#^dis,8-IMhG&Hp4LENh(X*/u^[UNp_!88`pQ^_+HNg5G7["8SZPQF7P_^Fkq,[3r4b+;O^s)8M`@B#jd,2UC=3t:>K-OYAmBZ>K[rRqK@:18gbN_=/7N0ZfY;NA9&!SQ;k(P*5`d0Z]pu#"SMu,APUHUN9nmOmZJOH(U7%g>A;n=JQV4BaZOU#I#@\J@(mFs57&30.>+Gl,NAM)D1q4DFCh%4g>'Q2bTY9m0Kk<pfhB"LaI^io:\'YEp?fq_nbrZ(n/hL[$gWp5ld5m<*RX7s3)j$3J)h7;AB>kN)\q81]J808+aXVEY4K4$Wu%t@P)]ks`ru>#:>L:bo^98VSR.A%k9QIX&]1qi#3c?\UR@^i/T-EC>^i$j]dNI9*<VIof,/LilM3;8`09bG]\DY_N)ROC:QN*CrBScOf6YOOg#j](b50qUG./>p&CMF)o]5LoAhJgFRKM]6m`aYfYsRLNKfKDn3!4)dp5+5eO2eVh(G+5iq:oWj`<5%0oEi(CTm'^U'A;ubIoSu1<RE_R3]e#5A:2al>&N^8LQT;H1gm0EQ7r$@d:I7aQGN!=a"Q=fIb$K"I%S&[c#E/2'LKr>~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1746
+>>
+stream
+Gatm;bAu>q']%q&m\Vd\a(7ZP/:/_%4R?[B1hj)9FJ0.3_D44r^]:$Bqs/S]5Z3g[CXIIhYrs4LTBDemPg^JA4T6r_U3A,6I?d_pU"'V6ZYW+3:NX-np&.nI^3R/_7D?^`35aKrDdYT'<CQ_8DaYO)gDItlgX>;<oVEh4aY\$Nak5%5P*b60eS%7.&QB,S<%4cM<NTgDF=TJ&j3EW>6>(Bla_l]n7N)WB'V;]$-a^I[eZUeZKNB&sZkLE)3hHd%*E;U7d)(mk;?Z<MW2'`_*r+Do,I_n#F4QW)SDp@fSIqa+3"1i)fS\*<l*K6mmnOQ(D?RUNm;/n8.8$U.OO\Y<bC_8I+kMdAJ+K<$NC7q(`(!C4qrCWh>"`@&"'O/Lp)[\#HjRWopJ^e((S0BtpNjE<)E,9-7EgQdEDgKCQjUBqSkTV`Z'15>.@#tFPK=\K/"6V&9A=gB?,c7Hk5i2%etYIh@rC?fpMldu]q.^"rj_8IT<:sdN9;igT"@s+fClsR.\jJL.[3B3Ys,FDU=PhB_Ru.nj3IM0`-hu!kT(#LZ.BFlo_@#S:,.,)?hL_g$9.EX$"X'mcN1W?kHfj0%_@ELO!oL+2/,u\GTV>KhU3rTpb*M8$2fTrQe',QLXY?>LXWTj0gG;TWR4>qkg63O.1Rk"lVUDqHA%g*dMoj^S.,Ob7p4RX0k<O*$0Tf-`/\62/1/R.-d0Gl&qa;B8f;g)%5XT_Nq#o6=+oQ9\*5WBpB'q+?W*b?P+.=o)Z\0&jK<\=dHo76$nXqId;?4pKCCTL)e:kQc1(RK#lO5$Nn_!Sj5j`j2Q&*uSBjHBfjm"c;<6mZ4cO#[`j/C.K_-<Y>a*KWV^dX)Y]Rj:FtASTI^Iddo:Ir<XX:;Aj.)0!%nmdr4f)36G]p.U3ZPNGk9>JA*`+0#KMXE#m)tp7MI,<5@$8qA4;Wd\V9?=#OlCb(KkV/f#`@)nkMXc=+*[i#^P-894[cWiPF^("GMh8lbF(jPica'7!Da%J/=6Ved"$mf=u1;iSWXIpdnJN-CP)cXb+9KFld"1%@rsc(nk/cal)!TPksdBNBCsHE]XV/@Gl5`Ng/N.@]S5rk?T;R)%sD?WjnPEFa3b]->Wan=!$mRd;b%E]?+pSRB,Q,s!s&0Wg`39LooLed"Ys4UNa[)ks!_PE4XHmNW.%#9T&dbqMfL&4\77(tHcoa6#%R6oOSCYO=:1(4@b$NDO/Hm'o?mh3JT=*;!::"B5c8MXLA)*7iO6QkhPqP..$?mH#c:LAd&FN[;M6!L`T%ZPhHaDC0b+aPT&oQ46<&'9O(j"t&05"fXdBcK8V;D>e1&ci:mMl?<$lSfE44HCJqPV1Wu:k#%<A+&.&r9@QL\>rSN;%)"`i<YfrGZPYr/dT61%jb]P";V8LlYa,XHBk==1B99+9!+UQ82-#$p]*`Rgn;NWkTl(B7fF4u?#&3J`uE;o@sG9`B:AP8gFB/Q>V0>@h!rTC#-o%s3F1CO%Vj,HKK_<Fa*RGcX[b#:A-BgrA^`FijNhb<+eecUcL%/-Gs]8*39qSVT,Da%(5rH^CGl06e,W@9^VS]<k"*-d])nn8,<dE6@XW!h@dND@AFg16jDUkcidDK](ka#`L#Fe4>pVgS]ZmQB9Y!Orm:[E)EA^aa4!KJO^4D0mlQd6J(!p<sej]_R5/->BFn9eNmoCQkZuO-1@pnh^l,Oe4OqZ3tfZ/)EnM8I.@o+?Y&e#D3?Z!Mer^Y'MmN4X+(0:+%YV~>endstream
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 734
+>>
+stream
+Gas2G9lJ`N&;KZOME*!unM_f>0l:rg+uT%Ub?ti7dB8i&XqC0h41h@872<+=QI5&H][,m`13rHcDDf4>"6jk:Glc.sng^W3H%Dl*nhJ6^RIbd(lWTGtQGo4s:ZP].Y#N]?d:8S,QDm66S#7;u_:Gn=$ejrL1\KTu6hGe/@qR?[G1[uu-G?ei$DBo/.f;o=70SSga%&bN@LB$Ni\l?(]S5JgRW!.dGsUIs)BCOJ1Hi.;GMHUCre/R_S2\g:al?9]2/iQl(q=)=;<$M.B,i>[c7P@%G3#N.<gHqBTeiCP`e,hH;RGU5X4Um>2E#^7%W#S;`tA$X.-n0o2>1Hm9`A'.SU\cQYL[8>C7So0FYTLSOr*"+iKFsUR>]R]lH_ri$cpL>rd>K1T"l;%VG:[<p,#%e\f%uk2SuOJY2Pt;s2Y);W$C7Qc,0>26le+1b=?g5^V\n_81:f(d@>;X]er)dd0C]=NqtgfkZ=kT'8*5V:3,/ki@uZKa;kSP%0g&7OJj!^akI1NJdhp_2=-!#02sm;a0k//"e70EG#1NdZUOA>jE`V*JrZ]$=Zr1=`P?BP*/B/d-j%ui'W``"rKg^k3t<!.Hqrj"P-7C]32!6\loi2FoC&oTg^n=sl%"+u=^9d2q.@XCgi,k?bBFS[S#`]\PuU(q)(i"C0$]unaLR+s`E'uu=NEV?`qulb8CKHnc*0kEGP\XlbHiD9W`7K^'35@D(Seh-&*IV/*W~>endstream
 endobj
 xref
-0 12
+0 14
 0000000000 65535 f 
 0000000061 00000 n 
 0000000112 00000 n 
 0000000219 00000 n 
 0000000331 00000 n 
 0000000436 00000 n 
-0000000630 00000 n 
-0000000824 00000 n 
-0000000892 00000 n 
-0000001172 00000 n 
-0000001237 00000 n 
-0000002950 00000 n 
+0000000631 00000 n 
+0000000826 00000 n 
+0000001021 00000 n 
+0000001090 00000 n 
+0000001370 00000 n 
+0000001442 00000 n 
+0000003126 00000 n 
+0000004964 00000 n 
 trailer
 <<
 /ID 
-[<9a4feaa4751b6e5c131679d84ef413f8><9a4feaa4751b6e5c131679d84ef413f8>]
+[<8746bf91327ef1bb3978e64af67a651b><8746bf91327ef1bb3978e64af67a651b>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 8 0 R
-/Root 7 0 R
-/Size 12
+/Info 9 0 R
+/Root 8 0 R
+/Size 14
 >>
 startxref
-4744
+5789
 %%EOF

--- a/src/Urrutia_Dario_Alfonso/solution.py
+++ b/src/Urrutia_Dario_Alfonso/solution.py
@@ -50,7 +50,7 @@ class MCTSNode:
         """
         return not untried_moves
 
-    def best_child(self, c_param: float = math.sqrt(2)) -> MCTSNode:
+    def best_child(self, c_param: float = 0.5) -> MCTSNode:
         """
         Selects the best child node based on:
           the UCT (Upper Confidence Bound for Trees) formula.

--- a/src/Urrutia_Dario_Alfonso/solution.py
+++ b/src/Urrutia_Dario_Alfonso/solution.py
@@ -88,6 +88,12 @@ class SmartPlayer(Player):
             A tuple (row, col) representing the chosen move.
         """
 
+        # Opening book: center is always strongest first move
+        empty_count = sum(cell == 0 for row in board.board for cell in row)
+        if empty_count == board.size * board.size:
+            center = board.size // 2
+            return (center, center)
+
         root = MCTSNode(board=board.clone())
         start_time = time.time()
         while time.time() - start_time < 4.5:
@@ -206,8 +212,14 @@ class SmartPlayer(Player):
         empty = self._get_untried_moves(sim_board)
         random.shuffle(empty)
 
+        last_move = None
         for move in empty:
+            if last_move is not None:
+                save = self._get_bridge_save(sim_board, last_move, current_player)
+                if save and sim_board.board[save[0]][save[1]] == 0:
+                    move = save
             sim_board.place_piece(row=move[0], col=move[1], player_id=current_player)
+            last_move = move
             current_player = 3 - current_player  # Switch player (1 <-> 2)
 
         return 1 if sim_board.check_connection(self.player_id) else 0
@@ -225,3 +237,51 @@ class SmartPlayer(Player):
             node.visits += 1
             node.wins += result
             node = node.parent
+
+    def _get_bridge_save(
+        self,
+        board: HexBoard,
+        last_move: tuple[int, int],
+        player: int,
+    ) -> tuple[int, int] | None:
+        """
+        Checks if the last move threatens a bridge and returns the saving move.
+
+        A bridge is a virtual connection between two pieces with two
+        empty cells between them. If one empty cell is played, the
+        other must be played to save the connection.
+
+        Args:
+            board: The current board state.
+            last_move: The move just played by the opponent.
+            player: The player whose bridges to protect.
+
+        Returns:
+            A saving move (row, col) if a bridge is threatened, None otherwise.
+        """
+        row, col = last_move
+        size = board.size
+
+        # Bridge patterns: (offset to friendly piece, offset to saving cell)
+        bridges = [
+            ((-1, 0), (-1, 1)),
+            ((-1, 1), (0, 1)),
+            ((0, 1), (1, 0)),
+            ((1, 0), (1, -1)),
+            ((1, -1), (0, -1)),
+            ((0, -1), (-1, 0)),
+        ]
+
+        for (dr1, dc1), (dr2, dc2) in bridges:
+            r1, c1 = row + dr1, col + dc1
+            r2, c2 = row + dr2, col + dc2
+
+            if not (0 <= r1 < size and 0 <= c1 < size):
+                continue
+            if not (0 <= r2 < size and 0 <= c2 < size):
+                continue
+
+            if board.board[r1][c1] == player and board.board[r2][c2] == 0:
+                return (r2, c2)
+
+        return None


### PR DESCRIPTION
## What this PR does
Improves SmartPlayer tournament performance with three heuristics
used by professional HEX AI (MoHex):

## Changes
- **Opening book** — first move always plays center (size//2, size//2)
- **Bridge save heuristic** — during simulation, saves virtual connections
  when opponent threatens them (heavy playouts)
- **UCB1 constant tuned** — C = 0.5 instead of sqrt(2), favoring
  exploitation over exploration in HEX
- **Updated estrategia.pdf** — documents all improvements

## Design Decisions
- Each improvement is a separate private method (Single Responsibility)
- Bridge save follows MoHex professional implementation
- All 19 existing tests still pass

## Related Issue
Closes #18